### PR TITLE
took out the logic allowing all request to server to authenticate

### DIFF
--- a/server/backend/backend/settings.py
+++ b/server/backend/backend/settings.py
@@ -127,4 +127,6 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ORIGIN_WHITELIST = (
+    'localhost:8080',
+)


### PR DESCRIPTION
now only requests from the front end app running on localhost:8080 will
be allowed